### PR TITLE
build(fix): Use Pyenv's Python defined in source checkout

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -511,8 +511,7 @@ setup_virtualenv() {
   if ! command -v virtualenv &> /dev/null; then
     log "Installing virtualenv"
     # We need to change to the checkout to use Pyenv's Python
-    cd $1
-    python -m pip install virtualenv
+    cd "$1" && python -m pip install virtualenv
     cd -
     logk
   fi
@@ -586,4 +585,3 @@ fi
 record_metric "bootstrap_passed"
 STRAP_SUCCESS="1"
 log "Your system is now bootstrapped! 🌮"
-

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -510,7 +510,10 @@ install_direnv() {
 setup_virtualenv() {
   if ! command -v virtualenv &> /dev/null; then
     log "Installing virtualenv"
+    # We need to change to the checkout to use Pyenv's Python
+    cd $1
     python -m pip install virtualenv
+    cd -
     logk
   fi
 


### PR DESCRIPTION
Without changing to the checkout, the script tries to use the system's
Python rather than the defined ones under `.python-version`.