### PR TITLE
feat: Do not use virtualenv package but venv module

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -508,17 +508,8 @@ install_direnv() {
 }
 
 setup_virtualenv() {
-  if ! command -v virtualenv &> /dev/null; then
-    log "Installing virtualenv"
-    # We need to change to the checkout to use Pyenv's Python
-    cd "$1" && python -m pip install virtualenv
-    cd -
-    logk
-  fi
-
-
   log "Creating virtualenv in $1"
-  cd "$1" && python -m virtualenv .venv
+  cd "$1" && python -m venv .venv
   logk
 }
 


### PR DESCRIPTION
Python 3 includes the `venv` module, thus, we don't need to install it.