### PR TITLE
feat: Support brew installation on Apple's M1 machines

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -306,9 +306,11 @@ install_homebrew() {
   # On Apple M1 machines we need to add this to the profile
   if [[ "$(uname -m)" == "arm64" ]]; then
     shell_profile=$(get_brew_profile)
-    #shellcheck disable=SC2016
-    echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >>${shell_profile}
-    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    if ! grep -qF "brew shellenv" "${shell_profile}"; then
+      #shellcheck disable=SC2016
+      echo -e 'eval "$(/opt/homebrew/bin/brew shellenv)"' >>${shell_profile}
+    fi
   fi
 
   # Install Homebrew Bundle, Cask and Services tap.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,7 @@
 #/ Usage: bin/strap.sh [--debug]
 #/ Install development dependencies on macOS.
 #/ Heavily inspired by https://github.com/MikeMcQuaid/strap
+# shellcheck disable=SC2086
 set -e
 
 # Default cloning value.
@@ -242,7 +243,6 @@ install_xcode_cli() {
 
 # Check if the Xcode license is agreed to and agree if not.
 xcode_license() {
-  # shellcheck disable=SC2086
   if /usr/bin/xcrun clang 2>&1 | grep $Q license; then
     if [ -n "$STRAP_INTERACTIVE" ]; then
       logn "Asking for Xcode license confirmation:"
@@ -289,13 +289,10 @@ install_homebrew() {
 
   # Download Homebrew.
   export GIT_DIR="$HOMEBREW_REPOSITORY/.git" GIT_WORK_TREE="$HOMEBREW_REPOSITORY"
-  # shellcheck disable=SC2086
   git init $Q
   git config remote.origin.url "https://github.com/Homebrew/brew"
   git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  # shellcheck disable=SC2086
   git fetch $Q --tags --force
-  # shellcheck disable=SC2086
   git reset $Q --hard origin/master
   unset GIT_DIR GIT_WORK_TREE
   logk
@@ -320,7 +317,6 @@ RUBY
 software_update() {
   logn "Checking for software updates:"
   updates=$(softwareupdate -l 2>&1)
-  # shellcheck disable=SC2086
   if $updates | grep $Q "No new software available."; then
     logk
   else

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -303,6 +303,14 @@ install_homebrew() {
   brew update --quiet
   logk
 
+  # On Apple M1 machines we need to add this to the profile
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    shell_profile=$(get_brew_profile)
+    #shellcheck disable=SC2016
+    echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >>${shell_profile}
+    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+  fi
+
   # Install Homebrew Bundle, Cask and Services tap.
   log "Installing Homebrew taps and extensions:"
   brew bundle --quiet --file=- <<RUBY
@@ -344,6 +352,26 @@ get_shell_name() {
     echo "zsh"
     ;;
   esac
+}
+
+# From https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+get_brew_profile() {
+  case "${SHELL}" in
+  */bash*)
+    if [[ -r "${HOME}/.bash_profile" ]]; then
+      shell_profile="${HOME}/.bash_profile"
+    else
+      shell_profile="${HOME}/.profile"
+    fi
+    ;;
+  */zsh*)
+    shell_profile="${HOME}/.zprofile"
+    ;;
+  *)
+    shell_profile="${HOME}/.profile"
+    ;;
+  esac
+  echo $shell_profile
 }
 
 get_shell_startup_script() {


### PR DESCRIPTION
brew installs under /opt/homebrew on Apple M1 machines.

This change brings code changes from the upstream [strap project][code].

[code]: https://github.com/MikeMcQuaid/strap/blob/e0c4fe4b173c90dbc8124effb40d0f5631121a9d/bin/strap.sh#L274-L305