### PR TITLE
fix: Install Sentry CLI after homebrew has been installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -550,8 +550,6 @@ bootstrap() {
 ## Beginning of execution ##
 ############################
 
-install_sentry_cli
-
 OSNAME="$(uname -s)"
 # TODO: Support other OSes
 if [ "$OSNAME" != "Darwin" ]; then
@@ -594,6 +592,7 @@ xcode_license
 SENTRY_ROOT="$CODE_ROOT/sentry"
 GETSENTRY_ROOT="$CODE_ROOT/getsentry"
 
+install_sentry_cli
 git_clone_repo "getsentry/sentry" "$SENTRY_ROOT"
 if [ -z "$SKIP_GETSENTRY" ] && ! git_clone_repo "getsentry/getsentry" "$GETSENTRY_ROOT" 2>/dev/null; then
   # git clone failed, assume no access to getsentry and skip further getsentry steps


### PR DESCRIPTION
Sentry CLI fails to install when `/usr/local/bin` is not around.

```
mv: rename /var/folders/rg/_rwy035d3wbd83f4xs57s3y40000gn/T//.sentrycli.n4rdLaQj to /usr/local/bin/sentry-cli: No such file or directory
```

This had been changed in #33, thus, the issue.

Filed upstream issue: https://github.com/getsentry/sentry-cli/issues/1070