### PR TITLE
feat: Uninstall brew & others

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -41,7 +41,6 @@ jobs:
       # This will ensure that we test the sentry-cli and brew installation step
       - name: Uninstall brew & others
         run: |
-          ls -l /usr/local/bin
           ./uninstall.sh
 
       - name: Execute bootstrap

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   fast-bootstrap:
     runs-on: macos-11
-    timeout-minutes: 45
+    timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
       # Make the environment more similar to what Mac defaults to
@@ -29,7 +29,7 @@ jobs:
 
   slow-bootstrap:
     runs-on: macos-11
-    timeout-minutes: 45
+    timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
       # Make the environment more similar to what Mac defaults to
@@ -37,6 +37,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      # This will ensure that we test the sentry-cli and brew installation step
+      - name: Uninstall brew & others
+        run: |
+          ls -l /usr/local/bin
+          ./uninstall.sh
 
       - name: Execute bootstrap
         env:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,7 +87,7 @@ https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/
 
 get_code_root_path() {
   if [ -z "$CODE_ROOT" ]; then
-    read -rp "--> Enter the absolute path to your code [$HOME/code]: " CODE_ROOT
+    read -rp "--> Enter absolute path where to clone source code [$HOME/code]: " CODE_ROOT
   else
     echo "Installing into $CODE_ROOT"
   fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,7 +87,7 @@ https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/
 
 get_code_root_path() {
   if [ -z "$CODE_ROOT" ]; then
-    read -rp "--> Enter absolute path where to clone source code [$HOME/code]: " CODE_ROOT
+    read -rp "--> Enter absolute path where we'll clone source code [$HOME/code]: " CODE_ROOT
   else
     echo "Installing into $CODE_ROOT"
   fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -389,6 +389,8 @@ get_shell_startup_script() {
 install_sentry_cli() {
   log "Installing sentry-cli"
   if ! command -v sentry-cli &>/dev/null; then
+    # This ensures that sentry-cli has a directory to install under
+    [ ! -d /usr/local/bin ] && sudo_askpass mkdir /usr/local/bin
     curl -sL https://sentry.io/get-cli/ | bash
   fi
   if [ -z "$CI" ]; then
@@ -576,6 +578,8 @@ sudo_refresh
 # Before starting, get the user's code location root where we will clone sentry repos to
 get_code_root_path
 
+install_sentry_cli
+
 [ -z "$CI" ] && [ -z "$QUICK" ] && check_github_access
 
 [ "$USER" = "root" ] && abort "Run as yourself, not root."
@@ -592,7 +596,7 @@ xcode_license
 SENTRY_ROOT="$CODE_ROOT/sentry"
 GETSENTRY_ROOT="$CODE_ROOT/getsentry"
 
-install_sentry_cli
+
 git_clone_repo "getsentry/sentry" "$SENTRY_ROOT"
 if [ -z "$SKIP_GETSENTRY" ] && ! git_clone_repo "getsentry/getsentry" "$GETSENTRY_ROOT" 2>/dev/null; then
   # git clone failed, assume no access to getsentry and skip further getsentry steps

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -390,7 +390,10 @@ install_sentry_cli() {
   log "Installing sentry-cli"
   if ! command -v sentry-cli &>/dev/null; then
     # This ensures that sentry-cli has a directory to install under
-    [ ! -d /usr/local/bin ] && sudo_askpass mkdir /usr/local/bin
+    [ ! -d /usr/local/bin ] && (
+      sudo_askpass mkdir /usr/local/bin;
+      sudo_askpass chown ${USER}:admin /usr/local/bin
+    )
     curl -sL https://sentry.io/get-cli/ | bash
   fi
   if [ -z "$CI" ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,11 +5,13 @@
 # This script tries to remove as much as reasonable to allow for re-testing
 # bootstrap.sh multiple times on the same host
 
-# Remove Sentry and dependencies
-rm -rf ~/.sentry
-rm -rf ~/code/sentry/{.venv,node_modules}
-rm -rf ~/code/getsentry/{.venv,node_modules}
-[ -f ~/.zprofile ] && rm ~/.zprofile
+remove_other() {
+    # Remove Sentry and dependencies
+    rm -rf ~/.sentry
+    rm -rf ~/code/sentry/{.venv,node_modules}
+    rm -rf ~/code/getsentry/{.venv,node_modules}
+    [ -f ~/.zprofile ] && rm ~/.zprofile
+}
 
 remove_brew_setup() {
     # Removes all packages
@@ -19,11 +21,13 @@ remove_brew_setup() {
     # Execute the official uninstall command
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
     # This is not removed by the script.
-    # On Intel machines, I would not dare removing /usr/local
-    [ -f /opt/homebrew ] && rm -rf /opt/homebrew
+    [ -d /opt/homebrew ] && sudo rm -rf /opt/homebrew
+    [ -d /usr/local/bin ] && sudo rm -rf /usr/local/bin
 }
 
 # Uninstall brew
 command -v brew &>/dev/null && remove_brew_setup
 
-echo "Successfully uninstalled brew and related packages"
+remove_other
+
+echo "Successfully uninstalled brew and other"


### PR DESCRIPTION
This change ensures that we uninstall brew and `sentry-cli` in order to test out that execution path.