### PR TITLE
feat(ci): Support checking out a different Sentry branch

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -24,6 +24,8 @@ jobs:
           # - Only install required libraries rather than brew bundle
           # - Skip updating Homebrew
           QUICK: 1
+          # You can use this to test a different Sentry branch
+          CI_CHECKOUT_BRANCH: armenzg/ci/dev-env-faster
         run: |
           ./bootstrap.sh
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -25,7 +25,7 @@ jobs:
           # - Skip updating Homebrew
           QUICK: 1
           # You can use this to test a different Sentry branch
-          CI_CHECKOUT_BRANCH: armenzg/ci/dev-env-faster
+          # CI_CHECKOUT_BRANCH: name_of_sentry_branch
         run: |
           ./bootstrap.sh
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -601,6 +601,8 @@ GETSENTRY_ROOT="$CODE_ROOT/getsentry"
 
 
 git_clone_repo "getsentry/sentry" "$SENTRY_ROOT"
+# This enables testing a different Sentry branch
+[ -n "$CI_CHECKOUT_BRANCH" ] && cd "$SENTRY_ROOT" && git checkout "$CI_CHECKOUT_BRANCH"
 if [ -z "$SKIP_GETSENTRY" ] && ! git_clone_repo "getsentry/getsentry" "$GETSENTRY_ROOT" 2>/dev/null; then
   # git clone failed, assume no access to getsentry and skip further getsentry steps
   SKIP_GETSENTRY=1


### PR DESCRIPTION
This is useful for Sentry's dev env CI check to make sure changes in a PR do not break contracts between Sentry's dev env and bootstrap-sentry (e.g. make targets).