### PR TITLE
feat(ci): Allow testing a different getsentry branch

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -404,12 +404,20 @@ install_sentry_cli() {
   logk
 }
 
-# Clone repo ($1) to path ($2)
+# Clone repo ($1) to path ($2) && checkout branch ($3)
 git_clone_repo() {
   if [ ! -d "$2" ]; then
     log "Cloning $1 to $2"
     git clone -q "${GIT_URL_PREFIX}$1.git" "$2"
     logk
+  fi
+  if [[ -n "$3" ]]; then
+    log "Checking out branch $3 for $2"
+    (
+      cd $2
+      git checkout $3
+      cd -
+    )
   fi
 }
 
@@ -600,10 +608,8 @@ SENTRY_ROOT="$CODE_ROOT/sentry"
 GETSENTRY_ROOT="$CODE_ROOT/getsentry"
 
 
-git_clone_repo "getsentry/sentry" "$SENTRY_ROOT"
-# This enables testing a different Sentry branch
-[ -n "$CI_CHECKOUT_BRANCH" ] && cd "$SENTRY_ROOT" && git checkout "$CI_CHECKOUT_BRANCH"
-if [ -z "$SKIP_GETSENTRY" ] && ! git_clone_repo "getsentry/getsentry" "$GETSENTRY_ROOT" 2>/dev/null; then
+git_clone_repo "getsentry/sentry" "$SENTRY_ROOT" "$CI_CHECKOUT_SENTRY_BRANCH"
+if [ -z "$SKIP_GETSENTRY" ] && ! git_clone_repo "getsentry/getsentry" "$GETSENTRY_ROOT" "$CI_CHECKOUT_GETSENTRY_BRANCH" 2>/dev/null; then
   # git clone failed, assume no access to getsentry and skip further getsentry steps
   SKIP_GETSENTRY=1
 fi


### PR DESCRIPTION
This is useful for getsentry PRs to test this script but pointing to the branch making changes.