### PR TITLE
fix: remove `exec "$SHELL"` which hangs forever

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -645,8 +645,6 @@ if [ -z "$SKIP_GETSENTRY" ] && [ -d "$GETSENTRY_ROOT" ]; then
   cd "$GETSENTRY_ROOT"
   log "You'll need to restart your shell and then run getsentry: \`exec $SHELL && getsentry devserver\`"
 else
-  # shellcheck disable=SC2093
-  exec "$SHELL"
   cd "$SENTRY_ROOT"
   log "You'll need to restart your shell and then run sentry: \`exec $SHELL && sentry devserver\`"
 fi


### PR DESCRIPTION
- a similar patch was done in d5ae35ce6f00617d1150805011ee371cb17462f4

___

test plan: `./bootstrap.sh`: succeeds