### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -24,8 +24,6 @@ jobs:
           # - Only install required libraries rather than brew bundle
           # - Skip updating Homebrew
           QUICK: 1
-          # You can use this to test a different Sentry branch
-          # CI_CHECKOUT_BRANCH: name_of_sentry_branch
         run: |
           ./bootstrap.sh
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           STRAP_DEBUG: 1
         run: |
+          sudo chown "$USER" /usr/local
           ./bootstrap.sh
 
       # This is import for assuring engineers that they can run the code once

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fast-bootstrap:
-    runs-on: macos-11
+    runs-on: macos-13
     timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
@@ -15,7 +15,7 @@ jobs:
       SHELL: /bin/zsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Execute bootstrap
         env:
@@ -30,7 +30,7 @@ jobs:
           ./bootstrap.sh
 
   slow-bootstrap:
-    runs-on: macos-11
+    runs-on: macos-13
     timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
@@ -38,7 +38,7 @@ jobs:
       SHELL: /bin/zsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # This will ensure that we test the sentry-cli and brew installation step
       - name: Uninstall brew & others

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
         pip install shellcheck-py==0.7.2.1
         shellcheck *.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -278,7 +278,7 @@ git_clone_repo() {
     log "Cloning $1 to $2"
     flags=
     [ -n "$CI" ] && flags='--depth=1'
-    git clone "$flags" "${GIT_URL_PREFIX}$1.git" "$2"
+    git clone $flags "${GIT_URL_PREFIX}$1.git" "$2"
     logk
   fi
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -416,6 +416,7 @@ STDIN_FILE_DESCRIPTOR="0"
 caffeinate -s -w $$ &
 
 sudo_refresh
+sudo networksetup -setv6off "Wi-Fi"
 install_xcode_cli
 xcode_license
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -280,7 +280,9 @@ install_sentry_cli() {
 git_clone_repo() {
   if [ ! -d "$2" ]; then
     log "Cloning $1 to $2"
-    git clone -q "${GIT_URL_PREFIX}$1.git" "$2"
+    flags=
+    [ -n "$CI" ] && flags='--depth=1'
+    git clone "$flags" "${GIT_URL_PREFIX}$1.git" "$2"
     logk
   fi
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -245,8 +245,10 @@ xcode_license() {
 install_homebrew() {
   logn "Installing Homebrew:"
   sudo_askpass chown "$USER" /opt
-  git clone --depth=1 "https://github.com/Homebrew/brew" /opt/homebrew
-  export PATH="/opt/homebrew/bin:${PATH}"
+  prefix="/opt/homebrew"
+  [ -z "$CI" ] && prefix="/usr/local"
+  git clone --depth=1 "https://github.com/Homebrew/brew" "$prefix"
+  export PATH="${prefix}/bin:${PATH}"
   [ -z "$QUICK" ] && {
     logn "Updating Homebrew:"
     brew update --quiet
@@ -255,7 +257,7 @@ install_homebrew() {
 
   if ! grep -qF "brew shellenv" "${HOME}/.zshrc"; then
     #shellcheck disable=SC2016
-    echo -e 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "${HOME}/.zshrc"
+    echo -e 'eval "$(${prefix}/bin/brew shellenv)"' >> "${HOME}/.zshrc"
   fi
   logk
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,14 +11,14 @@ GIT_URL_PREFIX="git@github.com:"
 CODE_ROOT="${HOME}/code"
 mkdir -p "$CODE_ROOT"
 
+touch "${HOME}/.zshrc"
+
 if [ -n "$CI" ]; then
   echo "Running within CI..."
   CODE_ROOT="$HOME/code"
   SKIP_METRICS=1
   GIT_URL_PREFIX="https://github.com/"
   SKIP_GETSENTRY=1
-  # The workflow sets the SHELL to zsh
-  touch "${HOME}/.zshrc"
 fi
 
 bootstrap_sentry="$HOME/.sentry/bootstrap-sentry"
@@ -324,21 +324,17 @@ setup_pyenv() {
 }
 
 install_sentry_env_vars() {
-  _script="${HOME}/.zshrc"
-
   logn "Installing sentry env vars to startup script..."
 
-  if [ -n "$_script" ]; then
-    # This will be used to measure webpack
-    if ! grep -qF "SENTRY_INSTRUMENTATION" "$_script"; then
-      echo "export SENTRY_INSTRUMENTATION=1" >>"$_script"
-    fi
-    if ! grep -qF "SENTRY_POST_MERGE_AUTO_UPDATE" "$_script"; then
-      echo "export SENTRY_POST_MERGE_AUTO_UPDATE=1" >>"$_script"
-    fi
-    if ! grep -qF "SENTRY_SPA_DSN" "$_script"; then
-      echo "export SENTRY_SPA_DSN=https://863de587a34a48c4a4ef1a9238fdb0b1@o19635.ingest.sentry.io/5270453" >>"$_script"
-    fi
+  # This will be used to measure webpack
+  if ! grep -qF "SENTRY_INSTRUMENTATION" "${HOME}/.zshrc"; then
+    echo "export SENTRY_INSTRUMENTATION=1" >>"${HOME}/.zshrc"
+  fi
+  if ! grep -qF "SENTRY_POST_MERGE_AUTO_UPDATE" "${HOME}/.zshrc"; then
+    echo "export SENTRY_POST_MERGE_AUTO_UPDATE=1" >> "${HOME}/.zshrc"
+  fi
+  if ! grep -qF "SENTRY_SPA_DSN" "${HOME}/.zshrc"; then
+    echo "export SENTRY_SPA_DSN=https://863de587a34a48c4a4ef1a9238fdb0b1@o19635.ingest.sentry.io/5270453" >> "${HOME}/.zshrc"
   fi
 
   logk
@@ -355,16 +351,10 @@ install_volta() {
 }
 
 install_direnv_startup() {
-  _script="${HOME}/.zshrc"
-
   logn "Installing direnv startup script..."
 
-  if [ -n "$_script" ]; then
-    if ! grep -qF "direnv hook" "$_script"; then
-      echo "eval \"\$(direnv hook zsh)\"" >>"$_script"
-    else
-      logn " skipping (already installed)... "
-    fi
+  if ! grep -qF "direnv hook" "${HOME}/.zshrc"; then
+    echo "eval \"\$(direnv hook zsh)\"" >> "${HOME}/.zshrc"
   fi
 
   logk

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -426,7 +426,7 @@ fi
 touch "${HOME}/.zshrc"
 
 sudo_refresh
-sudo networksetup -setv6off "Wi-Fi"
+[ -z "$CI" ] && sudo networksetup -setv6off "Wi-Fi"
 install_xcode_cli
 xcode_license
 install_sentry_cli

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,14 +5,6 @@
 # This script tries to remove as much as reasonable to allow for re-testing
 # bootstrap.sh multiple times on the same host
 
-remove_other() {
-    # Remove Sentry and dependencies
-    rm -rf ~/.sentry
-    rm -rf ~/code/sentry/{.venv,node_modules}
-    rm -rf ~/code/getsentry/{.venv,node_modules}
-    [ -f ~/.zprofile ] && rm ~/.zprofile
-}
-
 remove_brew_setup() {
     # Removes all packages
     brew list -1 | xargs brew rm
@@ -20,12 +12,13 @@ remove_brew_setup() {
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
     # This is not removed by the script.
     [ -d /opt/homebrew ] && sudo rm -rf /opt/homebrew
-    [ -d /usr/local/bin ] && sudo rm -rf /usr/local/bin
 }
 
-# Uninstall brew
 command -v brew &>/dev/null && remove_brew_setup
-
-remove_other
+rm -rf ~/.pyenv
+rm -rf ~/.sentry
+rm -rf ~/code/sentry/{.venv,node_modules}
+rm -rf ~/code/getsentry/{.venv,node_modules}
+[ -f ~/.zprofile ] && rm ~/.zprofile
 
 echo "Successfully uninstalled brew and other"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,8 @@
 
 if [ -n "$CI" ]; then
   # macos in GHA is intel-only, so make sure we remove its brew
-  sudo rm -rf /usr/local/bin/brew
+  sudo rm -rf /usr/local/Homebrew
+  sudo rm -f /usr/local/bin/brew
 fi
 
 sudo rm -rf /opt/homebrew
@@ -16,6 +17,4 @@ rm -rf ~/.pyenv
 rm -rf ~/.sentry
 rm -rf ~/code/sentry/{.venv,node_modules}
 rm -rf ~/code/getsentry/{.venv,node_modules}
-[ -f ~/.zprofile ] && rm ~/.zprofile
-
-echo "Successfully uninstalled brew and other"
+rm -f ~/.profile ~/.zprofile ~/.zshrc

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,16 +5,13 @@
 # This script tries to remove as much as reasonable to allow for re-testing
 # bootstrap.sh multiple times on the same host
 
-remove_brew_setup() {
-    # Removes all packages
-    brew list -1 | xargs brew rm
-    # Execute the official uninstall command
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
-    # This is not removed by the script.
-    [ -d /opt/homebrew ] && sudo rm -rf /opt/homebrew
-}
+if [ -n "$CI" ]; then
+  # macos in GHA is intel-only, so make sure we remove its brew
+  sudo rm -rf /usr/local/bin/brew
+fi
 
-command -v brew &>/dev/null && remove_brew_setup
+sudo rm -rf /opt/homebrew
+
 rm -rf ~/.pyenv
 rm -rf ~/.sentry
 rm -rf ~/code/sentry/{.venv,node_modules}


### PR DESCRIPTION
some updates+cleanup/simplification before a rewrite so 1) some quick/obvious improvements can be had and 2) i can have some more clarity

- new engineers start out with apple ARM on macos 13+, so i've removed intel support and updated CI to use macos-13
- since we have kandji there isn't much point to software_update reminder
- simpler+faster homebrew install
- better ordering (e.g. xcode goes first so that we have a python3 for sentry-cli installation)
- just support zsh, also just use zshrc rather than profile
- getsentry installs fine without devservices down
- disable ipv6 (IME yarn fails with ipv6 enabled)