### PR TITLE
only support macos 13.3+

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fast-bootstrap:
-    runs-on: macos-11
+    runs-on: macos-13
     timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
@@ -15,7 +15,7 @@ jobs:
       SHELL: /bin/zsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Execute bootstrap
         env:
@@ -24,13 +24,11 @@ jobs:
           # - Only install required libraries rather than brew bundle
           # - Skip updating Homebrew
           QUICK: 1
-          # You can use this to test a different Sentry branch
-          # CI_CHECKOUT_BRANCH: name_of_sentry_branch
         run: |
           ./bootstrap.sh
 
   slow-bootstrap:
-    runs-on: macos-11
+    runs-on: macos-13
     timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
@@ -38,7 +36,7 @@ jobs:
       SHELL: /bin/zsh
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # This will ensure that we test the sentry-cli and brew installation step
       - name: Uninstall brew & others

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
         pip install shellcheck-py==0.7.2.1
         shellcheck *.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -321,28 +321,6 @@ RUBY
   logk
 }
 
-# Check and install any remaining software updates.
-software_update() {
-  logn "Checking for software updates:"
-  updates=$(softwareupdate -l 2>&1)
-  if echo "$updates" | grep "$Q" "No new software available."; then
-    logk
-  else
-    echo
-    if [ "$1" == "reminder" ]; then
-      log "You have system updates to install. Please check for updates if you wish to install them."
-      log "$updates"
-    elif [ -z "$CI" ]; then
-      log "Installing software updates:"
-      sudo_askpass softwareupdate --install --all
-      xcode_license
-    else
-      echo "Skipping software updates for CI"
-    fi
-    logk
-  fi
-}
-
 get_shell_name() {
   case "$SHELL" in
   /bin/bash)
@@ -536,6 +514,14 @@ if [ "$OSNAME" != "Darwin" ]; then
   exit 1
 fi
 
+case "$(sw_vers -productVersion)" in
+    *11.*|*12.*|*13.0*|*13.1*|*13.2*)
+        # We need people to be on at least 13.3 for colima to work.
+        echo "Your Mac is on an unsupported version. Please upgrade to at least 13.3."
+        exit 1
+        ;;
+esac
+
 trap "cleanup" EXIT
 
 if [ -n "$STRAP_DEBUG" ]; then
@@ -622,5 +608,3 @@ fi
 record_metric "bootstrap_passed"
 STRAP_SUCCESS="1"
 log "Your system is now bootstrapped! 🌮"
-
-software_update "reminder"


### PR DESCRIPTION
First thing new people should do is update their Macs, before installing xcode tools. Let's make that happen. Also, 13.3+ is available and required for colima to work properly.

Also removes software_update at the end since we have Kandji.