### PR TITLE
ref: faster, simpler homebrew install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -321,7 +321,7 @@ install_sentry_cli() {
     # This ensures that sentry-cli has a directory to install under
     [ ! -d /usr/local/bin ] && (
       sudo_askpass mkdir /usr/local/bin
-      sudo_askpass chown ${USER}:admin /usr/local/bin
+      sudo_askpass chown "${USER}" /usr/local/bin
     )
     curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.0.4 bash
   fi
@@ -476,6 +476,8 @@ case "$(sw_vers -productVersion)" in
         ;;
 esac
 
+[ "$USER" = "root" ] && abort "Run as yourself, not root."
+
 trap "cleanup" EXIT
 
 if [ -n "$STRAP_DEBUG" ]; then
@@ -498,9 +500,6 @@ get_code_root_path
 install_sentry_cli
 
 [ -z "$CI" ] && [ -z "$QUICK" ] && check_github_access
-
-[ "$USER" = "root" ] && abort "Run as yourself, not root."
-groups | grep $Q -E "\b(admin)\b" || abort "Add $USER to the admin group."
 
 # Prevent sleeping during script execution, as long as the machine is on AC power
 caffeinate -s -w $$ &

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -266,7 +266,7 @@ install_homebrew() {
   [ -d "$HOMEBREW_REPOSITORY" ] || sudo_askpass mkdir -p "$HOMEBREW_REPOSITORY"
   sudo_askpass chown "$USER" "$HOMEBREW_REPOSITORY"
 
-  git -C "$HOMEBREW_REPOSITORY" clone --depth=1 "https://github.com/Homebrew/brew" .
+  git -C "$HOMEBREW_REPOSITORY" clone --depth=1 "https://github.com/Homebrew/brew" . || true
 
   # Update Homebrew.
   export PATH="${HOMEBREW_REPOSITORY}/bin:$PATH"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -263,8 +263,8 @@ install_homebrew() {
     HOMEBREW_REPOSITORY="/usr/local/Homebrew"
   fi
 
-  sudo_askpass chown "$USER" "$HOMEBREW_REPOSITORY" 2>/dev/null || true
-  [ -d "$HOMEBREW_REPOSITORY" ] || mkdir -p "$HOMEBREW_REPOSITORY"
+  [ -d "$HOMEBREW_REPOSITORY" ] || sudo_askpass mkdir -p "$HOMEBREW_REPOSITORY"
+  sudo_askpass chown "$USER" "$HOMEBREW_REPOSITORY"
 
   git -C "$HOMEBREW_REPOSITORY" clone --depth=1 "https://github.com/Homebrew/brew" .
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -258,11 +258,9 @@ install_homebrew() {
   logn "Installing Homebrew:"
 
   if [[ "$UNAME_MACHINE" == "arm64" ]]; then
-    HOMEBREW_PREFIX="/opt/homebrew"
-    HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}"
+    HOMEBREW_REPOSITORY="/opt/homebrew"
   else
-    HOMEBREW_PREFIX="/usr/local"
-    HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
+    HOMEBREW_REPOSITORY="/usr/local/Homebrew"
   fi
 
   sudo_askpass chown "$USER" "$HOMEBREW_REPOSITORY" 2>/dev/null || true

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -257,7 +257,7 @@ install_homebrew() {
   # Setup Homebrew directory and permissions.
   logn "Installing Homebrew:"
 
-  if [[ "$UNAME_MACHINE" == "arm64" ]]; then
+  if [[ "$(/usr/bin/uname -m)" == "arm64" ]]; then
     HOMEBREW_REPOSITORY="/opt/homebrew"
   else
     HOMEBREW_REPOSITORY="/usr/local/Homebrew"
@@ -266,7 +266,7 @@ install_homebrew() {
   [ -d "$HOMEBREW_REPOSITORY" ] || sudo_askpass mkdir -p "$HOMEBREW_REPOSITORY"
   sudo_askpass chown "$USER" "$HOMEBREW_REPOSITORY"
 
-  git -C "$HOMEBREW_REPOSITORY" clone --depth=1 "https://github.com/Homebrew/brew" . || true
+  git -C "$HOMEBREW_REPOSITORY" clone -q --depth=1 "https://github.com/Homebrew/brew" . || true
 
   # Update Homebrew.
   export PATH="${HOMEBREW_REPOSITORY}/bin:$PATH"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -268,16 +268,6 @@ install_homebrew() {
 
   git -C "$HOMEBREW_REPOSITORY" clone --depth=1 "https://github.com/Homebrew/brew" .
 
-  # Download Homebrew.
-  export GIT_DIR="$HOMEBREW_REPOSITORY/.git" GIT_WORK_TREE="$HOMEBREW_REPOSITORY"
-  git init $Q
-  git config remote.origin.url "https://github.com/Homebrew/brew"
-  git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  git fetch $Q --tags --force
-  git reset $Q --hard origin/master
-  unset GIT_DIR GIT_WORK_TREE
-  logk
-
   # Update Homebrew.
   export PATH="${HOMEBREW_REPOSITORY}/bin:$PATH"
   [ -z "$QUICK" ] && {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -19,8 +19,8 @@ remove_brew_setup() {
     # Execute the official uninstall command
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
     # This is not removed by the script.
-    [ -d /opt/homebrew ] && sudo rm -rf /opt/homebrew
-    [ -d /usr/local/bin ] && sudo rm -rf /usr/local/bin
+    sudo rm -rf /opt/homebrew
+    sudo rm -rf /usr/local/Homebrew
 }
 
 # Uninstall brew


### PR DESCRIPTION
Still gonna support Intel Mac for now to keep the changes small.

Good simplification by just thinking about HOMEBREW_REPOSITORY. We chown it before a git clone. Homebrew operates and updates itself just fine with a depth 1 inital clone. Write to shellrc instead of profile since `brew` won't be in PATH if people `exec` to reload the shell. 