### PR TITLE
ref: xcode install goes before sentry-cli to give it a python3

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
     paths:
-      - '*.sh'
+      - 'bootstrap.sh'
 
 jobs:
   shellcheck:
@@ -15,4 +15,4 @@ jobs:
     - uses: actions/checkout@v3
     - run: |
         pip install shellcheck-py==0.7.2.1
-        shellcheck *.sh
+        shellcheck bootstrap.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -497,15 +497,13 @@ sudo_refresh
 # Before starting, get the user's code location root where we will clone sentry repos to
 get_code_root_path
 
-install_sentry_cli
-
-[ -z "$CI" ] && [ -z "$QUICK" ] && check_github_access
-
 # Prevent sleeping during script execution, as long as the machine is on AC power
 caffeinate -s -w $$ &
 
 install_xcode_cli
 xcode_license
+install_sentry_cli
+[ -z "$CI" ] && [ -z "$QUICK" ] && check_github_access
 [ -z "$QUICK" ] && install_homebrew
 
 ### Sentry stuff ###

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -277,7 +277,7 @@ install_homebrew() {
   logk
 
   shell_rc=$(get_shell_startup_script)
-  if ! grep -qF "brew shellenv" "$shell_rc"; then
+  if ! /usr/bin/grep -sF "brew shellenv" "$shell_rc"; then
     #shellcheck disable=SC2016
     echo -e 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$shell_rc"
   fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -257,7 +257,7 @@ install_homebrew() {
   # Setup Homebrew directory and permissions.
   logn "Installing Homebrew:"
 
-  if [[ "$UNAME_MACHINE" == "arm64" ]]; then
+  if [[ "$(/usr/bin/uname -m)" == "arm64" ]]; then
     HOMEBREW_REPOSITORY="/opt/homebrew"
   else
     HOMEBREW_REPOSITORY="/usr/local/Homebrew"
@@ -266,7 +266,7 @@ install_homebrew() {
   [ -d "$HOMEBREW_REPOSITORY" ] || sudo_askpass mkdir -p "$HOMEBREW_REPOSITORY"
   sudo_askpass chown "$USER" "$HOMEBREW_REPOSITORY"
 
-  git -C "$HOMEBREW_REPOSITORY" clone --depth=1 "https://github.com/Homebrew/brew" . || true
+  git -C "$HOMEBREW_REPOSITORY" clone -q --depth=1 "https://github.com/Homebrew/brew" . || true
 
   # Update Homebrew.
   export PATH="${HOMEBREW_REPOSITORY}/bin:$PATH"

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+[[ "$CI" ]] || read -p "Don't execute this unless you know what you're doing. ENTER to continue."
+[[ "$CI" ]] || read -p "Seriously, don't execute this. ENTER to continue."
+
+mv -v "${1}/homebrew" /opt/homebrew
+# mv -v "${1}/Homebrew" /usr/local/Homebrew
+mv -v "${1}/sentry" ~/code
+mv -v "${1}/getsentry" ~/code
+mv -v "${1}/".* ~
+rmdir "$1"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,7 +3,8 @@
 stuff="/opt/homebrew /usr/local/Homebrew ${HOME}/.sentry ${HOME}/code/sentry ${HOME}/code/getsentry ${HOME}/.profile ${HOME}/.zprofile ${HOME}/.zshrc"
 
 [[ "$CI" ]] && {
-    rm -rf $stuff
+    # sudo shouldn't be necessary since we chown it, but it is necessary in CI's case as it comes preinstalled
+    sudo rm -rf $stuff
     exit
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,31 +1,15 @@
 #!/bin/bash
-# WARNING: You take full resposibility of what could happen to your host when executing
-#          this script. This script has only been tested on Armen's MBP arm64 machine
-#
-# This script tries to remove as much as reasonable to allow for re-testing
-# bootstrap.sh multiple times on the same host
 
-remove_other() {
-    # Remove Sentry and dependencies
-    rm -rf ~/.sentry
-    rm -rf ~/code/sentry/{.venv,node_modules}
-    rm -rf ~/code/getsentry/{.venv,node_modules}
-    [ -f ~/.zprofile ] && rm ~/.zprofile
+stuff="/opt/homebrew /usr/local/Homebrew ${HOME}/.sentry ${HOME}/code/sentry ${HOME}/code/getsentry ${HOME}/.profile ${HOME}/.zprofile ${HOME}/.zshrc"
+
+[[ "$CI" ]] && {
+    rm -rf $stuff
+    exit
 }
 
-remove_brew_setup() {
-    # Removes all packages
-    brew list -1 | xargs brew rm
-    # Execute the official uninstall command
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
-    # This is not removed by the script.
-    sudo rm -rf /opt/homebrew
-    sudo rm -rf /usr/local/Homebrew
-}
+[[ "$CI" ]] || read -p "Don't execute this unless you know what you're doing. ENTER to continue."
+[[ "$CI" ]] || read -p "Seriously, don't execute this. ENTER to continue."
 
-# Uninstall brew
-command -v brew &>/dev/null && remove_brew_setup
-
-remove_other
-
-echo "Successfully uninstalled brew and other"
+backup="${HOME}/.sentry-bootstrap-$(date +%s)"
+mkdir "$backup"
+mv -v $stuff "$backup"


### PR DESCRIPTION
this will be obsolete once I start bringing in a redistributable python to serve as the official devenv runtime but in the meantime, this will stop sentry-cli install from failing on 1st try

also - wrote an actual backup/restore with warnings