### PR TITLE
Because we do a shallow clone, the CI branch returns an error

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @getsentry/dev-infra

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -502,7 +502,7 @@ GETSENTRY_ROOT="$CODE_ROOT/getsentry"
 
 git_clone_repo "getsentry/sentry" "$SENTRY_ROOT"
 # This enables testing a different Sentry branch
-[ -n "$CI_CHECKOUT_BRANCH" ] && cd "$SENTRY_ROOT" && git checkout "$CI_CHECKOUT_BRANCH"
+[ -n "$CI_CHECKOUT_BRANCH" ] && cd "$SENTRY_ROOT" && git fetch origin && git checkout "$CI_CHECKOUT_BRANCH"
 if [ -z "$SKIP_GETSENTRY" ] && ! git_clone_repo "getsentry/getsentry" "$GETSENTRY_ROOT" 2>/dev/null; then
   # git clone failed, assume no access to getsentry and skip further getsentry steps
   SKIP_GETSENTRY=1


### PR DESCRIPTION
Example: https://github.com/getsentry/sentry/actions/runs/6165667268/job/16733858869\?pr\=56114

+ adding codeowners